### PR TITLE
internal/ci: fix unity dispatch

### DIFF
--- a/.github/workflows/unity_dispatch.yml
+++ b/.github/workflows/unity_dispatch.yml
@@ -18,5 +18,5 @@ jobs:
           git config user.name porcuepine
           git config user.email porcuepine@gmail.com
           git config http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n porcuepine:${{ secrets.PORCUEPINE_GITHUB_PAT }} | base64)"
-          git checkout -b unity/${{ github.event.client_payload.payload.changeID }}/${{ github.event.client_payload.payload.commit }}
-          git push https://github.com/cue-unity/unity-trybot unity/${{ github.event.client_payload.payload.changeID }}/${{ github.event.client_payload.payload.commit }}
+          git checkout -b unity/${{ github.event.client_payload.payload.cl.changeID }}/${{ github.event.client_payload.payload.cl.commit }}
+          git push https://github.com/cue-unity/unity-trybot unity/${{ github.event.client_payload.payload.cl.changeID }}/${{ github.event.client_payload.payload.cl.commit }}

--- a/internal/ci/github/unity_dispatch.cue
+++ b/internal/ci/github/unity_dispatch.cue
@@ -24,7 +24,7 @@ import (
 // is concerned, compared to unity_cli.
 unity_dispatch: _base.#bashWorkflow & {
 	_#type:                 _gerrithub.#dispatchUnity
-	_#branchNameExpression: "\(_#type)/${{ github.event.client_payload.payload.changeID }}/${{ github.event.client_payload.payload.commit }}"
+	_#branchNameExpression: "\(_#type)/${{ github.event.client_payload.payload.cl.changeID }}/${{ github.event.client_payload.payload.cl.commit }}"
 	name:                   "Dispatch \(_#type)"
 	on: ["repository_dispatch"]
 	jobs: {


### PR DESCRIPTION
The unity dispatch has cl and a versions fields in the payload, to
distinguish between what is a CL-based trigger (i.e. part of the
trybots) and a CLI-based trigger (i.e. someone testing from the command
line). A copy-paste-style error from the main CUE repo resulted in us
not dereferencing via the cl field for the changeID and commit. Fix
that.

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: I38dfd933c88a422579e17f97d8cabdc56136dc24