### PR TITLE
internal/ci: unshallow clone of unity default branch

### DIFF
--- a/.github/workflows/unity_dispatch.yml
+++ b/.github/workflows/unity_dispatch.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Trigger unity
         run: |-
           git config user.name porcuepine

--- a/internal/ci/github/unity_dispatch.cue
+++ b/internal/ci/github/unity_dispatch.cue
@@ -35,8 +35,13 @@ unity_dispatch: _base.#bashWorkflow & {
 				// This workflow is triggered against the tip of the default branch.
 				// We want to create a branch named unity/$changeID/$revisionID
 				// and push that to the trybot repository to trigger the unity
-				// workflow.
-				_base.#checkoutCode,
+				// workflow. We need full history in order to be able to push
+				// to the unity-trybot repository.
+				_base.#checkoutCode & {
+					with: {
+						"fetch-depth": 0
+					}
+				},
 				json.#step & {
 					name: "Trigger \(_#type)"
 					run:  """


### PR DESCRIPTION
If we only do a shallow clone (default) then we cannot push to
unity-trybot (shallow update not allowed).

Signed-off-by: Paul Jolly <paul@myitcv.io>
Change-Id: I83460f1b466a97c34eca753e93a6fedab6f88cc0